### PR TITLE
Bump hadoop-common from 2.8.2 to 3.2.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
     </repositories>
     <properties>
         <storm.version>1.2.2</storm.version>
-        <hadoop.version>2.8.2</hadoop.version>
+        <hadoop.version>3.2.3</hadoop.version>
     </properties>
     <dependencies>
         <dependency>


### PR DESCRIPTION
Bumps hadoop-common from 2.8.2 to 3.2.3.

---
updated-dependencies:
- dependency-name: org.apache.hadoop:hadoop-common dependency-type: direct:production ...

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
- [ ] I have read the [Code of Conduct](https://github.com/danopstech/.github/blob/main/CODE_OF_CONDUCT.md)
- [ ] I have updated the documentation accordingly.
- [ ] All commits are GPG signed
